### PR TITLE
Implementation of a generic BFN and queues as lazy lists

### DIFF
--- a/Makefile.conf
+++ b/Makefile.conf
@@ -8,7 +8,7 @@
 #                                                                             #
 ###############################################################################
 
-COQMF_VFILES = bft.v bt.v queues.v bfn.v fifo.v bfn_fifo.v bft_spec.v php.v list_utils.v wf_utils.v zip.v sorted.v increase.v llist.v bfn_fifo_2l.v
+COQMF_VFILES = bft.v bt.v queues.v bfn.v fifo.v bfn_fifo.v bft_spec.v php.v list_utils.v wf_utils.v zip.v sorted.v increase.v llist.v bfn_fifo_2l.v bfn_fifo_gen.v
 COQMF_MLIFILES = 
 COQMF_MLFILES = 
 COQMF_ML4FILES = 

--- a/Makefile.conf
+++ b/Makefile.conf
@@ -8,7 +8,7 @@
 #                                                                             #
 ###############################################################################
 
-COQMF_VFILES = bft.v bt.v queues.v bfn.v fifo.v bfn_fifo.v bft_spec.v php.v list_utils.v wf_utils.v zip.v sorted.v increase.v
+COQMF_VFILES = bft.v bt.v queues.v bfn.v fifo.v bfn_fifo.v bft_spec.v php.v list_utils.v wf_utils.v zip.v sorted.v increase.v llist.v bfn_fifo_2l.v
 COQMF_MLIFILES = 
 COQMF_MLFILES = 
 COQMF_ML4FILES = 

--- a/Makefile.conf
+++ b/Makefile.conf
@@ -8,7 +8,7 @@
 #                                                                             #
 ###############################################################################
 
-COQMF_VFILES = bft.v bt.v queues.v bfn.v fifo.v bfn_fifo.v bft_spec.v php.v list_utils.v wf_utils.v zip.v sorted.v increase.v llist.v bfn_fifo_2l.v bfn_fifo_gen.v
+COQMF_VFILES = bft.v bt.v queues.v bfn.v fifo.v bfn_fifo.v bft_spec.v php.v list_utils.v wf_utils.v zip.v sorted.v increase.v llist.v bfn_fifo_2l.v bfn_fifo_gen.v bfn_fifo_3q.v
 COQMF_MLIFILES = 
 COQMF_MLFILES = 
 COQMF_ML4FILES = 

--- a/_CoqProject
+++ b/_CoqProject
@@ -15,3 +15,4 @@ increase.v
 llist.v
 bfn_fifo_2l.v
 bfn_fifo_gen.v
+bfn_fifo_3q.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -12,3 +12,5 @@ wf_utils.v
 zip.v
 sorted.v
 increase.v
+llist.v
+bfn_fifo_2l.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -14,3 +14,4 @@ sorted.v
 increase.v
 llist.v
 bfn_fifo_2l.v
+bfn_fifo_gen.v

--- a/bfn_fifo.v
+++ b/bfn_fifo.v
@@ -83,11 +83,11 @@ Section bfn.
       | true  => fun H1 => exist _ fifo_nil _
       | false => fun H1 => _
     end eq_refl).
-    { rewrite fifo_void_spec in H1.
+    { apply fifo_void_spec in H1.
       rewrite H1, fifo_nil_spec; split; simpl; auto.
       red; rewrite bft_f_fix_0; simpl; auto. }
     assert (fifo_list p <> nil) as H2.
-    { red; rewrite <- fifo_void_spec, H1; discriminate. }
+    { red; intros H; apply fifo_void_spec in H; rewrite H in H1; discriminate. }
     refine (match fifo_deq p H2 as k return fifo_deq p H2 = k -> _ with
       | (leaf x ,p') => _
       | (node a x b, p') => _
@@ -130,65 +130,11 @@ Section bfn.
       rewrite bft_f_fix_3; simpl; split; auto.
   Defined.
 
-  Fixpoint bfn_f_gen' n (p : fX) (D : Acc (fun x y => fifo_sum x < fifo_sum y) p) : { q : fN | fifo_list p ~lt rev (fifo_list q) /\ is_bfn_from n (rev (fifo_list q)) }.
-  Proof.
-    refine (match fifo_void p as b return fifo_void p = b -> _ with
-      | true  => fun H1 => exist _ fifo_nil _
-      | false => fun H1 => _
-    end eq_refl).
-    { rewrite fifo_void_spec in H1.
-      rewrite H1, fifo_nil_spec; split; simpl; auto.
-      red; rewrite bft_f_fix_0; simpl; auto. }
-    assert (fifo_list p <> nil) as H2.
-    { red; rewrite <- fifo_void_spec, H1; discriminate. }
-    refine (match fifo_deq p H2 as k return fifo_deq p H2 = k -> _ with
-      | (leaf x ,p') => _
-      | (node a x b, p') => _
-    end eq_refl); intros H3.
-    + generalize (fifo_deq_spec _ p H2); rewrite H3; intros H4.
-      refine (let (q,Hq) := bfn_f_gen' (S n) p' _ in exist _ (fifo_enq q (leaf n)) _).
-      { apply Acc_inv with (1 := D); unfold fifo_sum; rewrite H4; simpl; omega. }
-      destruct Hq as (H5 & H6).
-      rewrite H4, fifo_enq_spec.
-      subst; split; auto.
-      rewrite rev_app_distr; simpl; auto.
-      rewrite rev_app_distr; simpl; red.
-      rewrite bft_f_fix_3; simpl; rewrite <- app_nil_end; auto.
-    + generalize (fifo_deq_spec _ p H2); rewrite H3; intros H4.
-      refine (let (q,Hq) := bfn_f_gen' (S n) (fifo_enq (fifo_enq p' a) b) _ in _).
-      { apply Acc_inv with (1 := D); unfold fifo_sum. 
-        rewrite fifo_enq_spec, fifo_enq_spec, app_ass; simpl.
-        rewrite lsum_app, H4; simpl; omega. }
-      destruct Hq as (H5 & H6).
-      rewrite fifo_enq_spec, fifo_enq_spec, app_ass in H5; simpl in H5.
-      assert (2 <= length (fifo_list q)) as H7.
-      { apply Forall2_length in H5.
-        rewrite app_length, rev_length in H5.
-        simpl in H5; omega. }
-      assert (fifo_list q <> nil) as H8.
-      { revert H7; destruct (fifo_list q); simpl; try discriminate; intro; omega. } 
-      generalize (fifo_deq_spec _ _ H8).
-      refine (match fifo_deq _ H8 with (u,q') => _ end); intros H9.
-      assert (fifo_list q' <> nil) as H10.
-      { revert H7; rewrite H9; destruct (fifo_list q'); simpl; try discriminate; intro; omega. }
-      generalize (fifo_deq_spec _ _ H10).
-      refine (match fifo_deq _ H10 with (v,q'') => _ end); intros H11.
-      exists (fifo_enq q'' (node v n u)).
-      rewrite H4, fifo_enq_spec, rev_app_distr; simpl.
-      rewrite H9, H11 in H5; simpl in H5; rewrite app_ass in H5; simpl in H5.
-      rewrite H9, H11 in H6; simpl in H6; rewrite app_ass in H6; simpl in H6.
-      unfold is_bfn_from in H6 |- *.
-      apply Forall2_2snoc_inv in H5.
-      destruct H5 as (G1 & G2 & H5).
-      rewrite bft_f_fix_3; simpl; split; auto.
-  Defined.
-
   Section bfn.
 
     Let bfn_full (t : bt X) : { t' | t ~t t' /\ is_seq_from 0 (bft_std t') }.
     Proof.
       refine (match @bfn_f_gen 0 (fifo_enq fifo_nil t) with exist _ q Hq => _ end).
-    (*  { apply Acc_measure. } *)
       rewrite fifo_enq_spec, fifo_nil_spec in Hq; simpl in Hq.
       destruct Hq as (H1 & H2).
       assert (fifo_list q <> nil) as H3.

--- a/bfn_fifo_2l.v
+++ b/bfn_fifo_2l.v
@@ -1,0 +1,181 @@
+(**************************************************************)
+(*   Copyright Dominique Larchey-Wendling [*]                 *)
+(*                                                            *)
+(*                             [*] Affiliation LORIA -- CNRS  *)
+(**************************************************************)
+(*      This file is distributed under the terms of the       *)
+(*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
+(**************************************************************)
+
+(** Extraction of breadth-first numbering algorithm from Coq to Ocaml 
+
+       see http://okasaki.blogspot.com/2008/07/breadth-first-numbering-algorithm-in.html
+       and https://www.westpoint.edu/eecs/SiteAssets/SitePages/Faculty%20Publication%20Documents/Okasaki/jfp95queue.pdf
+       and https://www.cs.cmu.edu/~rwh/theses/okasaki.pdf
+       and https://www.westpoint.edu/eecs/SiteAssets/SitePages/Faculty%20Publication%20Documents/Okasaki/icfp00bfn.pdf
+
+*)
+
+Require Import List Arith Omega Extraction.
+Require Import list_utils wf_utils bt bft fifo.
+
+Set Implicit Arguments.
+
+Section seq_an.
+
+  (* seq_an a n = [a;a+1;...;a+(n-1)] *)
+
+  Fixpoint seq_an a n: list nat :=
+    match n with
+      | 0    => nil
+      | S n  => a::seq_an (S a) n
+    end.
+
+  Fact seq_an_length a n : length (seq_an a n) = n.
+  Proof. revert a; induction n; simpl; intros; f_equal; auto. Qed.
+
+  Fact seq_an_spec a n x : In x (seq_an a n) <-> a <= x < a+n.
+  Proof. 
+    revert x a; induction n as [ | n IHn ]; intros x a; simpl;
+      [ | rewrite IHn ]; omega.
+  Qed.
+
+  Fixpoint is_seq_from n (l : list nat) { struct l }: Prop :=
+    match l with  
+      | nil  => True
+      | x::l => n=x /\ is_seq_from (S n) l
+    end.
+
+  Theorem is_seq_from_spec a l : is_seq_from a l <-> exists n, l = seq_an a n.
+  Proof.
+    revert a; induction l as [ | x l IH ]; intros a; simpl.
+    + split; auto; exists 0; auto.
+    + rewrite IH; split.
+      * intros (? & n & Hn); subst x; exists (S n); subst; auto.
+      * intros ([ | n ] & ?); subst; try discriminate.
+        simpl in H; inversion H; subst; split; auto.
+        exists n; auto.
+  Qed.
+
+End seq_an.
+
+Definition fifo_2l_sum { X } (q : fifo_2l (bt X)) := lsum (fifo_2l_list q). 
+
+Section bfn.
+
+  Variable (X : Type).
+
+  Notation fX := (fifo_2l (bt X)). 
+  Notation fN := (fifo_2l (bt nat)).
+
+  (* the forest (list of bt nat) is a breadth first numbering from n if
+     its breadth first traversal yields [n;n+1;....;m[ for some m
+   *)
+
+  Let fX_spec := fifo_2l_spec (bt X).
+  Let fN_spec := fifo_2l_spec (bt nat).
+
+  Definition is_bfn_from n l := is_seq_from n (bft_f l).
+
+  (* Breath First Numbering: maps a forest X to a forest nat such that
+          1) the two forests are of the same shape
+          2) the result is a breadth first numbering from n  
+   *)
+
+  Definition bfn_2l_f n (p : fX) : { q : fN | fifo_2l_list p ~lt rev (fifo_2l_list q) /\ is_bfn_from n (rev (fifo_2l_list q)) }.
+  Proof.
+    induction on n p as bfn_2l_f with measure (fifo_2l_sum p).
+    refine (match fifo_2l_void p as b return fifo_2l_void p = b -> _ with
+      | true  => fun H1 => exist _ fifo_2l_nil _
+      | false => fun H1 => _
+    end eq_refl).
+    { apply fifo_2l_void_spec in H1.
+      rewrite H1, fifo_2l_nil_spec; split; simpl; auto.
+      red; rewrite bft_f_fix_0; simpl; auto. }
+    assert (fifo_2l_list p <> nil) as H2.
+    { intro E; apply fifo_2l_void_spec in E; rewrite E in H1; discriminate. }
+    refine (match fifo_2l_deq p H2 as k return fifo_2l_deq p H2 = k -> _ with
+      | (leaf x ,p') => _
+      | (node a x b, p') => _
+    end eq_refl); intros H3.
+    + generalize (fifo_2l_deq_spec _ H2); rewrite H3; intros H4.
+      refine (let (q,Hq) := bfn_2l_f (S n) p' _ in exist _ (fifo_2l_enq q (leaf n)) _).
+      { unfold fifo_2l_sum; rewrite H4; simpl; omega. }
+      destruct Hq as (H5 & H6).
+      rewrite H4, fifo_2l_enq_spec.
+      subst; split; auto.
+      rewrite rev_app_distr; simpl; auto.
+      rewrite rev_app_distr; simpl; red.
+      rewrite bft_f_fix_3; simpl; rewrite <- app_nil_end; auto.
+    + generalize (fifo_2l_deq_spec _ H2); rewrite H3; intros H4.
+      refine (let (q,Hq) := bfn_2l_f (S n) (fifo_2l_enq (fifo_2l_enq p' a) b) _ in _).
+      { unfold fifo_2l_sum. 
+        rewrite fifo_2l_enq_spec, fifo_2l_enq_spec, app_ass; simpl.
+        rewrite lsum_app, H4; simpl; omega. }
+      destruct Hq as (H5 & H6).
+      rewrite fifo_2l_enq_spec, fifo_2l_enq_spec, app_ass in H5; simpl in H5.
+      assert (2 <= length (fifo_2l_list q)) as H7.
+      { apply Forall2_length in H5.
+        rewrite app_length, rev_length in H5.
+        simpl in H5; omega. }
+      assert (fifo_2l_list q <> nil) as H8.
+      { revert H7; destruct (fifo_2l_list q); simpl; try discriminate; intro; omega. } 
+      generalize (fifo_2l_deq_spec _ H8).
+      refine (match fifo_2l_deq _ H8 with (u,q') => _ end); intros H9.
+      assert (fifo_2l_list q' <> nil) as H10.
+      { revert H7; rewrite H9; destruct (fifo_2l_list q'); simpl; try discriminate; intro; omega. }
+      generalize (fifo_2l_deq_spec _ H10).
+      refine (match fifo_2l_deq _ H10 with (v,q'') => _ end); intros H11.
+      exists (fifo_2l_enq q'' (node v n u)).
+      rewrite H4, fifo_2l_enq_spec, rev_app_distr; simpl.
+      rewrite H9, H11 in H5; simpl in H5; rewrite app_ass in H5; simpl in H5.
+      rewrite H9, H11 in H6; simpl in H6; rewrite app_ass in H6; simpl in H6.
+      unfold is_bfn_from in H6 |- *.
+      apply Forall2_2snoc_inv in H5.
+      destruct H5 as (G1 & G2 & H5).
+      rewrite bft_f_fix_3; simpl; split; auto.
+  Defined.
+
+  Section bfn.
+
+    Let bfn_2l_full (t : bt X) : { t' | t ~t t' /\ is_seq_from 0 (bft_std t') }.
+    Proof.
+      refine (match @bfn_2l_f 0 (fifo_2l_enq fifo_2l_nil t) with exist _ q Hq => _ end).
+      rewrite fifo_2l_enq_spec, fifo_2l_nil_spec in Hq; simpl in Hq.
+      destruct Hq as (H1 & H2).
+      assert (fifo_2l_list q <> nil) as H3.
+      { apply Forall2_length in H1; rewrite rev_length in H1.
+        destruct (fifo_2l_list q); discriminate. }
+      generalize (fifo_2l_deq_spec _ H3).
+      refine (match fifo_2l_deq _ H3 with (x,q') => _ end); intros H4.
+      exists x.
+      rewrite <- bft_std_eq_bft.
+      rewrite H4 in H1; simpl in H1.
+      apply Forall2_snoc_inv with (l := nil) in H1.
+      destruct H1 as (G1 & H1).
+      apply Forall2_nil_inv_right in H1.
+      apply f_equal with (f := @rev _) in H1.
+      rewrite rev_involutive in H1; simpl in H1.
+      rewrite H4, H1 in H2; simpl in H2.
+      auto.
+    Qed.
+
+    Definition bfn_2l t := proj1_sig (bfn_2l_full t).
+
+    Fact bfn_2l_spec_1 t : t ~t bfn_2l t.
+    Proof. apply (proj2_sig (bfn_2l_full t)). Qed.
+
+    Fact bfn_2l_spec_2 t : exists n, bft_std (bfn_2l t) = seq_an 0 n.
+    Proof. apply is_seq_from_spec, (proj2_sig (bfn_2l_full t)). Qed.
+
+  End bfn.
+
+End bfn.
+
+Recursive Extraction bfn_2l.
+
+Check bfn_2l.
+Check bfn_2l_spec_1.
+Check bfn_2l_spec_2.
+             
+

--- a/bfn_fifo_2l.v
+++ b/bfn_fifo_2l.v
@@ -79,7 +79,9 @@ Section bfn.
 
   (* Breath First Numbering: maps a forest X to a forest nat such that
           1) the two forests are of the same shape
-          2) the result is a breadth first numbering from n  
+          2) the result is a breadth first numbering from n
+
+     Beware that the output is a reversed queue compared to the input
    *)
 
   Definition bfn_2l_f n (p : fX) : { q : fN | fifo_2l_list p ~lt rev (fifo_2l_list q) /\ is_bfn_from n (rev (fifo_2l_list q)) }.

--- a/bfn_fifo_2l.v
+++ b/bfn_fifo_2l.v
@@ -25,7 +25,7 @@ Section seq_an.
 
   (* seq_an a n = [a;a+1;...;a+(n-1)] *)
 
-  Fixpoint seq_an a n: list nat :=
+  Fixpoint seq_an a n : list nat :=
     match n with
       | 0    => nil
       | S n  => a::seq_an (S a) n
@@ -43,7 +43,7 @@ Section seq_an.
   Fixpoint is_seq_from n (l : list nat) { struct l }: Prop :=
     match l with  
       | nil  => True
-      | x::l => n=x /\ is_seq_from (S n) l
+      | x::l => n = x /\ is_seq_from (S n) l
     end.
 
   Theorem is_seq_from_spec a l : is_seq_from a l <-> exists n, l = seq_an a n.
@@ -59,9 +59,9 @@ Section seq_an.
 
 End seq_an.
 
-Definition fifo_2l_sum { X } (q : fifo_2l (bt X)) := lsum (fifo_2l_list q). 
-
 Section bfn.
+
+  Let fifo_2l_sum { X } (q : fifo_2l (bt X)) := lsum (fifo_2l_list q). 
 
   Variable (X : Type).
 
@@ -171,6 +171,9 @@ Section bfn.
   End bfn.
 
 End bfn.
+
+(* Notice that fifo_2l_deq is extracted to a function that loops forever
+   if the input is the empty queue, ie does not following the spec *)
 
 Recursive Extraction bfn_2l.
 

--- a/bfn_fifo_3q.v
+++ b/bfn_fifo_3q.v
@@ -1,0 +1,186 @@
+(**************************************************************)
+(*   Copyright Dominique Larchey-Wendling [*]                 *)
+(*                                                            *)
+(*                             [*] Affiliation LORIA -- CNRS  *)
+(**************************************************************)
+(*      This file is distributed under the terms of the       *)
+(*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
+(**************************************************************)
+
+(** Extraction of breadth-first numbering algorithm from Coq to Ocaml 
+
+       see http://okasaki.blogspot.com/2008/07/breadth-first-numbering-algorithm-in.html
+       and https://www.westpoint.edu/eecs/SiteAssets/SitePages/Faculty%20Publication%20Documents/Okasaki/jfp95queue.pdf
+       and https://www.cs.cmu.edu/~rwh/theses/okasaki.pdf
+       and https://www.westpoint.edu/eecs/SiteAssets/SitePages/Faculty%20Publication%20Documents/Okasaki/icfp00bfn.pdf
+
+*)
+
+Require Import List Arith Omega Extraction.
+Require Import list_utils wf_utils bt bft fifo.
+
+Set Implicit Arguments.
+
+Section seq_an.
+
+  (* seq_an a n = [a;a+1;...;a+(n-1)] *)
+
+  Fixpoint seq_an a n : list nat :=
+    match n with
+      | 0    => nil
+      | S n  => a::seq_an (S a) n
+    end.
+
+  Fact seq_an_length a n : length (seq_an a n) = n.
+  Proof. revert a; induction n; simpl; intros; f_equal; auto. Qed.
+
+  Fact seq_an_spec a n x : In x (seq_an a n) <-> a <= x < a+n.
+  Proof. 
+    revert x a; induction n as [ | n IHn ]; intros x a; simpl;
+      [ | rewrite IHn ]; omega.
+  Qed.
+
+  Fixpoint is_seq_from n (l : list nat) { struct l }: Prop :=
+    match l with  
+      | nil  => True
+      | x::l => n = x /\ is_seq_from (S n) l
+    end.
+
+  Theorem is_seq_from_spec a l : is_seq_from a l <-> exists n, l = seq_an a n.
+  Proof.
+    revert a; induction l as [ | x l IH ]; intros a; simpl.
+    + split; auto; exists 0; auto.
+    + rewrite IH; split.
+      * intros (? & n & Hn); subst x; exists (S n); subst; auto.
+      * intros ([ | n ] & ?); subst; try discriminate.
+        simpl in H; inversion H; subst; split; auto.
+        exists n; auto.
+  Qed.
+
+End seq_an.
+
+Section bfn.
+
+  Let fifo_3q_sum { X } (q : fifo_3q (bt X)) := lsum (fifo_3q_list q). 
+
+  Variable (X : Type).
+
+  Notation fX := (fifo_3q (bt X)). 
+  Notation fN := (fifo_3q (bt nat)).
+
+  (* the forest (list of bt nat) is a breadth first numbering from n if
+     its breadth first traversal yields [n;n+1;....;m[ for some m
+   *)
+
+  Let fX_spec := fifo_3q_spec (bt X).
+  Let fN_spec := fifo_3q_spec (bt nat).
+
+  Definition is_bfn_from n l := is_seq_from n (bft_f l).
+
+  (* Breath First Numbering: maps a forest X to a forest nat such that
+          1) the two forests are of the same shape
+          2) the result is a breadth first numbering from n
+
+     Beware that the output is a reversed queue compared to the input
+   *)
+
+  Definition bfn_3q_f n (p : fX) : { q : fN | fifo_3q_list p ~lt rev (fifo_3q_list q) /\ is_bfn_from n (rev (fifo_3q_list q)) }.
+  Proof.
+    induction on n p as bfn_3q_f with measure (fifo_3q_sum p).
+    refine (match fifo_3q_void p as b return fifo_3q_void p = b -> _ with
+      | true  => fun H1 => exist _ fifo_3q_nil _
+      | false => fun H1 => _
+    end eq_refl).
+    { apply fifo_3q_void_spec in H1.
+      rewrite H1, fifo_3q_nil_spec; split; simpl; auto.
+      red; rewrite bft_f_fix_0; simpl; auto. }
+    assert (fifo_3q_list p <> nil) as H2.
+    { intro E; apply fifo_3q_void_spec in E; rewrite E in H1; discriminate. }
+    refine (match fifo_3q_deq p H2 as k return fifo_3q_deq p H2 = k -> _ with
+      | (leaf x ,p') => _
+      | (node a x b, p') => _
+    end eq_refl); intros H3.
+    + generalize (fifo_3q_deq_spec _ H2); rewrite H3; intros H4.
+      refine (let (q,Hq) := bfn_3q_f (S n) p' _ in exist _ (fifo_3q_enq q (leaf n)) _).
+      { unfold fifo_3q_sum; rewrite H4; simpl; omega. }
+      destruct Hq as (H5 & H6).
+      rewrite H4, fifo_3q_enq_spec.
+      subst; split; auto.
+      rewrite rev_app_distr; simpl; auto.
+      rewrite rev_app_distr; simpl; red.
+      rewrite bft_f_fix_3; simpl; rewrite <- app_nil_end; auto.
+    + generalize (fifo_3q_deq_spec _ H2); rewrite H3; intros H4.
+      refine (let (q,Hq) := bfn_3q_f (S n) (fifo_3q_enq (fifo_3q_enq p' a) b) _ in _).
+      { unfold fifo_3q_sum. 
+        rewrite fifo_3q_enq_spec, fifo_3q_enq_spec, app_ass; simpl.
+        rewrite lsum_app, H4; simpl; omega. }
+      destruct Hq as (H5 & H6).
+      rewrite fifo_3q_enq_spec, fifo_3q_enq_spec, app_ass in H5; simpl in H5.
+      assert (2 <= length (fifo_3q_list q)) as H7.
+      { apply Forall2_length in H5.
+        rewrite app_length, rev_length in H5.
+        simpl in H5; omega. }
+      assert (fifo_3q_list q <> nil) as H8.
+      { revert H7; destruct (fifo_3q_list q); simpl; try discriminate; intro; omega. } 
+      generalize (fifo_3q_deq_spec _ H8).
+      refine (match fifo_3q_deq _ H8 with (u,q') => _ end); intros H9.
+      assert (fifo_3q_list q' <> nil) as H10.
+      { revert H7; rewrite H9; destruct (fifo_3q_list q'); simpl; try discriminate; intro; omega. }
+      generalize (fifo_3q_deq_spec _ H10).
+      refine (match fifo_3q_deq _ H10 with (v,q'') => _ end); intros H11.
+      exists (fifo_3q_enq q'' (node v n u)).
+      rewrite H4, fifo_3q_enq_spec, rev_app_distr; simpl.
+      rewrite H9, H11 in H5; simpl in H5; rewrite app_ass in H5; simpl in H5.
+      rewrite H9, H11 in H6; simpl in H6; rewrite app_ass in H6; simpl in H6.
+      unfold is_bfn_from in H6 |- *.
+      apply Forall2_2snoc_inv in H5.
+      destruct H5 as (G1 & G2 & H5).
+      rewrite bft_f_fix_3; simpl; split; auto.
+  Defined.
+
+  Section bfn.
+
+    Let bfn_3q_full (t : bt X) : { t' | t ~t t' /\ is_seq_from 0 (bft_std t') }.
+    Proof.
+      refine (match @bfn_3q_f 0 (fifo_3q_enq fifo_3q_nil t) with exist _ q Hq => _ end).
+      rewrite fifo_3q_enq_spec, fifo_3q_nil_spec in Hq; simpl in Hq.
+      destruct Hq as (H1 & H2).
+      assert (fifo_3q_list q <> nil) as H3.
+      { apply Forall2_length in H1; rewrite rev_length in H1.
+        destruct (fifo_3q_list q); discriminate. }
+      generalize (fifo_3q_deq_spec _ H3).
+      refine (match fifo_3q_deq _ H3 with (x,q') => _ end); intros H4.
+      exists x.
+      rewrite <- bft_std_eq_bft.
+      rewrite H4 in H1; simpl in H1.
+      apply Forall2_snoc_inv with (l := nil) in H1.
+      destruct H1 as (G1 & H1).
+      apply Forall2_nil_inv_right in H1.
+      apply f_equal with (f := @rev _) in H1.
+      rewrite rev_involutive in H1; simpl in H1.
+      rewrite H4, H1 in H2; simpl in H2.
+      auto.
+    Qed.
+
+    Definition bfn_3q t := proj1_sig (bfn_3q_full t).
+
+    Fact bfn_3q_spec_1 t : t ~t bfn_3q t.
+    Proof. apply (proj2_sig (bfn_3q_full t)). Qed.
+
+    Fact bfn_3q_spec_2 t : exists n, bft_std (bfn_3q t) = seq_an 0 n.
+    Proof. apply is_seq_from_spec, (proj2_sig (bfn_3q_full t)). Qed.
+
+  End bfn.
+
+End bfn.
+
+(* Notice that fifo_3q_deq is extracted to a function that loops forever
+   if the input is the empty queue, ie does not following the spec *)
+
+Recursive Extraction bfn_3q.
+
+Check bfn_3q.
+Check bfn_3q_spec_1.
+Check bfn_3q_spec_2.
+             
+

--- a/bfn_fifo_gen.v
+++ b/bfn_fifo_gen.v
@@ -1,0 +1,215 @@
+(**************************************************************)
+(*   Copyright Dominique Larchey-Wendling [*]                 *)
+(*                                                            *)
+(*                             [*] Affiliation LORIA -- CNRS  *)
+(**************************************************************)
+(*      This file is distributed under the terms of the       *)
+(*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
+(**************************************************************)
+
+(** Extraction of breadth-first numbering algorithm from Coq to Ocaml 
+
+       see http://okasaki.blogspot.com/2008/07/breadth-first-numbering-algorithm-in.html
+       and https://www.westpoint.edu/eecs/SiteAssets/SitePages/Faculty%20Publication%20Documents/Okasaki/jfp95queue.pdf
+       and https://www.cs.cmu.edu/~rwh/theses/okasaki.pdf
+       and https://www.westpoint.edu/eecs/SiteAssets/SitePages/Faculty%20Publication%20Documents/Okasaki/icfp00bfn.pdf
+
+*)
+
+Require Import List Arith Omega Extraction.
+Require Import list_utils wf_utils bt bft fifo.
+
+Set Implicit Arguments.
+
+Section seq_an.
+
+  (* seq_an a n = [a;a+1;...;a+(n-1)] *)
+
+  Fixpoint seq_an a n : list nat :=
+    match n with
+      | 0    => nil
+      | S n  => a::seq_an (S a) n
+    end.
+
+  Fact seq_an_length a n : length (seq_an a n) = n.
+  Proof. revert a; induction n; simpl; intros; f_equal; auto. Qed.
+
+  Fact seq_an_spec a n x : In x (seq_an a n) <-> a <= x < a+n.
+  Proof. 
+    revert x a; induction n as [ | n IHn ]; intros x a; simpl;
+      [ | rewrite IHn ]; omega.
+  Qed.
+
+  Fixpoint is_seq_from n (l : list nat) { struct l }: Prop :=
+    match l with  
+      | nil  => True
+      | x::l => n = x /\ is_seq_from (S n) l
+    end.
+
+  Theorem is_seq_from_spec a l : is_seq_from a l <-> exists n, l = seq_an a n.
+  Proof.
+    revert a; induction l as [ | x l IH ]; intros a; simpl.
+    + split; auto; exists 0; auto.
+    + rewrite IH; split.
+      * intros (? & n & Hn); subst x; exists (S n); subst; auto.
+      * intros ([ | n ] & ?); subst; try discriminate.
+        simpl in H; inversion H; subst; split; auto.
+        exists n; auto.
+  Qed.
+
+End seq_an.
+
+Section bfn.
+
+  Variable (fifo      : Type -> Type) 
+           (fifo_list : forall X, fifo X -> list X)
+           (fifo_nil  : forall X, fifo X)
+           (fifo_enq  : forall X, fifo X -> X -> fifo X)
+           (fifo_deq  : forall X q, @fifo_list X q <> nil -> X * fifo X)
+           (fifo_void : forall X, fifo X -> bool)
+           (fifo_nil_spec  : forall X, fifo_nil_prop (@fifo_list X) (fifo_nil X))
+           (fifo_enq_spec  : forall X, fifo_enq_prop (@fifo_list X) (@fifo_enq X)) 
+           (fifo_deq_spec  : forall X, fifo_deq_prop (@fifo_list X) (@fifo_deq X)) 
+           (fifo_void_spec : forall X, fifo_void_prop (@fifo_list X) (@fifo_void X)).
+
+  Let fifo_sum { X } (q : fifo (bt X)) := lsum (fifo_list q). 
+
+  Variable (X : Type).
+
+  Notation fX := (fifo (bt X)). 
+  Notation fN := (fifo (bt nat)).
+
+  (* the forest (list of bt nat) is a breadth first numbering from n if
+     its breadth first traversal yields [n;n+1;....;m[ for some m
+   *)
+
+  Definition is_bfn_from n l := is_seq_from n (bft_f l).
+
+  (* Breath First Numbering: maps a forest X to a forest nat such that
+          1) the two forests are of the same shape
+          2) the result is a breadth first numbering from n
+
+     Beware that the output is a reversed queue compared to the input
+   *)
+
+  Definition bfn_gen_f n (p : fX) : { q : fN | fifo_list p ~lt rev (fifo_list q) /\ is_bfn_from n (rev (fifo_list q)) }.
+  Proof.
+    induction on n p as bfn_gen_f with measure (fifo_sum p).
+    refine (match fifo_void p as b return fifo_void p = b -> _ with
+      | true  => fun H1 => exist _ (@fifo_nil _) _
+      | false => fun H1 => _
+    end eq_refl).
+    { apply fifo_void_spec in H1.
+      rewrite H1, fifo_nil_spec; split; simpl; auto.
+      red; rewrite bft_f_fix_0; simpl; auto. }
+    assert (fifo_list p <> nil) as H2.
+    { intro E; apply fifo_void_spec in E; rewrite E in H1; discriminate. }
+    refine (match fifo_deq H2 as k return fifo_deq H2 = k -> _ with
+      | (leaf x ,p') => _
+      | (node a x b, p') => _
+    end eq_refl); intros H3.
+    + generalize (fifo_deq_spec H2); rewrite H3; intros H4.
+      refine (let (q,Hq) := bfn_gen_f (S n) p' _ in exist _ (fifo_enq q (leaf n)) _).
+      { unfold fifo_sum; rewrite H4; simpl; omega. }
+      destruct Hq as (H5 & H6).
+      rewrite H4, fifo_enq_spec.
+      subst; split; auto.
+      rewrite rev_app_distr; simpl; auto.
+      rewrite rev_app_distr; simpl; red.
+      rewrite bft_f_fix_3; simpl; rewrite <- app_nil_end; auto.
+    + generalize (fifo_deq_spec H2); rewrite H3; intros H4.
+      refine (let (q,Hq) := bfn_gen_f (S n) (fifo_enq (fifo_enq p' a) b) _ in _).
+      { unfold fifo_sum. 
+        rewrite fifo_enq_spec, fifo_enq_spec, app_ass; simpl.
+        rewrite lsum_app, H4; simpl; omega. }
+      destruct Hq as (H5 & H6).
+      rewrite fifo_enq_spec, fifo_enq_spec, app_ass in H5; simpl in H5.
+      assert (2 <= length (fifo_list q)) as H7.
+      { apply Forall2_length in H5.
+        rewrite app_length, rev_length in H5.
+        simpl in H5; omega. }
+      assert (fifo_list q <> nil) as H8.
+      { revert H7; destruct (fifo_list q); simpl; try discriminate; intro; omega. } 
+      generalize (fifo_deq_spec H8).
+      refine (match fifo_deq H8 with (u,q') => _ end); intros H9.
+      assert (fifo_list q' <> nil) as H10.
+      { revert H7; rewrite H9; destruct (fifo_list q'); simpl; try discriminate; intro; omega. }
+      generalize (fifo_deq_spec H10).
+      refine (match fifo_deq H10 with (v,q'') => _ end); intros H11.
+      exists (fifo_enq q'' (node v n u)).
+      rewrite H4, fifo_enq_spec, rev_app_distr; simpl.
+      rewrite H9, H11 in H5; simpl in H5; rewrite app_ass in H5; simpl in H5.
+      rewrite H9, H11 in H6; simpl in H6; rewrite app_ass in H6; simpl in H6.
+      unfold is_bfn_from in H6 |- *.
+      apply Forall2_2snoc_inv in H5.
+      destruct H5 as (G1 & G2 & H5).
+      rewrite bft_f_fix_3; simpl; split; auto.
+  Defined.
+
+  Section bfn.
+
+    Let bfn_full (t : bt X) : { t' | t ~t t' /\ is_seq_from 0 (bft_std t') }.
+    Proof.
+      refine (match @bfn_gen_f 0 (fifo_enq (@fifo_nil _) t) with exist _ q Hq => _ end).
+      rewrite fifo_enq_spec, fifo_nil_spec in Hq; simpl in Hq.
+      destruct Hq as (H1 & H2).
+      assert (fifo_list q <> nil) as H3.
+      { apply Forall2_length in H1; rewrite rev_length in H1.
+        destruct (fifo_list q); discriminate. }
+      generalize (fifo_deq_spec H3).
+      refine (match fifo_deq H3 with (x,q') => _ end); intros H4.
+      exists x.
+      rewrite <- bft_std_eq_bft.
+      rewrite H4 in H1; simpl in H1.
+      apply Forall2_snoc_inv with (l := nil) in H1.
+      destruct H1 as (G1 & H1).
+      apply Forall2_nil_inv_right in H1.
+      apply f_equal with (f := @rev _) in H1.
+      rewrite rev_involutive in H1; simpl in H1.
+      rewrite H4, H1 in H2; simpl in H2.
+      auto.
+    Qed.
+
+    Definition bfn_gen t := proj1_sig (bfn_full t).
+
+    Fact bfn_gen_spec_1 t : t ~t bfn_gen t.
+    Proof. apply (proj2_sig (bfn_full t)). Qed.
+
+    Fact bfn_gen_spec_2 t : exists n, bft_std (bfn_gen t) = seq_an 0 n.
+    Proof. apply is_seq_from_spec, (proj2_sig (bfn_full t)). Qed.
+
+  End bfn.
+
+End bfn.
+
+(* Notice that fifo_2l_deq is extracted to a function that loops forever
+   if the input is the empty queue, ie does not following the spec *)
+
+Recursive Extraction bfn_gen.
+
+Check bfn_gen.
+Check bfn_gen_spec_1.
+Check bfn_gen_spec_2.
+
+Section bfn_2q.
+
+  Variable X : Type.
+
+  Definition bfn_2q := @bfn_gen _ _ _ _ _ _ fifo_2q_nil_spec fifo_2q_enq_spec fifo_2q_deq_spec fifo_2q_void_spec X.
+
+  Definition bfn_2q_spec_1 t : t ~t bfn_2q t.
+  Proof. apply bfn_gen_spec_1. Qed.
+
+  Definition bfn_2q_spec_2 t : exists n, bft_std (bfn_2q t) = seq_an 0 n.
+  Proof. apply bfn_gen_spec_2. Qed.
+
+End bfn_2q.
+
+Extraction Inline bfn_gen.
+Recursive Extraction bfn_2q.
+
+Check bfn_2q.
+Check bfn_2q_spec_1.
+Check bfn_2q_spec_2.
+
+

--- a/fifo.v
+++ b/fifo.v
@@ -484,7 +484,14 @@ Section fifo_three_lazy_lists.
       rewrite llist_list_fix_1; discriminate.
   Qed.
 
+  Hint Resolve fifo_3q_nil_spec fifo_3q_enq_spec fifo_3q_deq_spec fifo_3q_void_spec.
+
+  Theorem fifo_3q_spec : fifo_props fifo_3q_list fifo_3q_nil fifo_3q_enq fifo_3q_deq fifo_3q_void.
+  Proof. red; auto. Qed.
+
 End fifo_three_lazy_lists.
+
+Arguments fifo_3q_nil {X}.
 
 Recursive Extraction fifo_3q_nil fifo_3q_enq fifo_3q_deq fifo_3q_void.
 

--- a/fifo.v
+++ b/fifo.v
@@ -194,25 +194,8 @@ Section fifo_two_lazy_lists.
       exists (lfin_rotate _ _ (@lfin_lnil _) E), (@lfin_lnil _).
       rewrite llist_rotate_length.
       generalize (llist_rotate_length _ _ (@lfin_lnil _) E); intros H.
- 
- , lnil,0
-    refine (match n with 
-      | 0 => fun E => 
-    intros ((l,r),H).
-
-    
-
-  Definition fifo_2q_enq (q : Q) (x : X) : Q.
-  Proof.
-    destruct q as ((l,r),H); simpl in H.
-    
-    refine (match q with exist _ q Hq => _ end).
+  Admitted.
 
 End fifo_two_lazy_lists.
 
- 
-  
-
-
-End fifo_two_lazy_lists.
 

--- a/fifo.v
+++ b/fifo.v
@@ -33,12 +33,12 @@ Section fifo_props.
 End fifo_props.
 
 Record fifo (X : Type) := {
-  Q :> Type;
-  fifo_list : Q -> list X; 
-  fifo_nil : Q; 
-  fifo_enq : Q -> X -> Q;
-  fifo_deq : forall q, fifo_list q <> nil -> X * Q;
-  fifo_void : Q -> bool;
+  queue :> Type;
+  fifo_list : queue -> list X; 
+  fifo_nil : queue; 
+  fifo_enq : queue -> X -> queue;
+  fifo_deq : forall q, fifo_list q <> nil -> X * queue;
+  fifo_void : queue -> bool;
   fifo_nil_spec : fifo_nil_prop fifo_list fifo_nil;
   fifo_enq_spec : fifo_enq_prop fifo_list fifo_enq;
   fifo_deq_spec : fifo_deq_prop fifo_list fifo_deq;
@@ -84,24 +84,23 @@ Section rev_linear.
   Variable (X : Type).
   Implicit Type (l m : list X).
 
-  Let rev_aux : list X -> list X -> list X :=
-    fix loop l m { struct m } :=
-      match m with
-        | nil  => l
-        | x::m => loop (x::l) m
-      end.
+  Fixpoint rev' l m :=
+    match m with
+      | nil  => l
+      | x::m => rev' (x::l) m
+    end.
 
-  Let rev_aux_spec l m : rev_aux l m = rev m ++ l.
+  Let rev'_spec l m : rev' l m = rev m ++ l.
   Proof.
     revert l; induction m as [ | x m IHm ]; simpl; intros l; auto.
     rewrite IHm, app_ass; auto.
   Qed.
 
-  Definition rev_linear l: list X := rev_aux nil l.
+  Definition rev_linear l: list X := rev' nil l.
 
   Fact rev_linear_spec l : rev_linear l = rev l.
   Proof.
-    unfold rev_linear; rewrite rev_aux_spec, <- app_nil_end; auto.
+    unfold rev_linear; rewrite rev'_spec, <- app_nil_end; auto.
   Qed.
 
 End rev_linear.
@@ -171,13 +170,45 @@ End fifo_two_lists.
 
 Arguments fifo_2l_nil {X}.
 
-Recursive Extraction fifo_two_lists.
-
 Section fifo_two_lazy_lists.
 
   (** From "Simple and Efficient Purely Functional Queues and Deques" by Chris Okasaki *)
 
   Variable X : Type.
+
+  Implicit Types (l r : llist X).
+
+  Let Q_spec (c : llist X * llist X * nat) :=
+    match c with (l,r,n) => exists Hl Hr, n + lfin_length r Hr = lfin_length l Hl end.
+
+  Definition fifo_2q_nil : sig Q_spec.
+  Proof. 
+    exists (lnil,lnil,0), (lfin_lnil _), (lfin_lnil _); simpl.
+    rewrite lfin_length_fix_0; auto.
+  Defined.
+
+  Definition fifo_2q_make l r (Hl : lfin l) (Hr : lfin r) n : n + lfin_length r Hr = 1 + lfin_length l Hl -> sig Q_spec.
+  Proof.
+    destruct n as [ | n ]; intros E.
+    + exists (llist_rotate (@lfin_lnil _) E, lnil,0); simpl.
+      exists (lfin_rotate _ _ (@lfin_lnil _) E), (@lfin_lnil _).
+      rewrite llist_rotate_length.
+      generalize (llist_rotate_length _ _ (@lfin_lnil _) E); intros H.
+ 
+ , lnil,0
+    refine (match n with 
+      | 0 => fun E => 
+    intros ((l,r),H).
+
+    
+
+  Definition fifo_2q_enq (q : Q) (x : X) : Q.
+  Proof.
+    destruct q as ((l,r),H); simpl in H.
+    
+    refine (match q with exist _ q Hq => _ end).
+
+End fifo_two_lazy_lists.
 
  
   

--- a/llist.v
+++ b/llist.v
@@ -129,6 +129,9 @@ Section llist.
   Definition lfin_length l Hl := length (llist_list l Hl).
 
   Arguments lfin_length : clear implicits.
+
+  Fact lfin_length_eq l H1 H2 : lfin_length l H1 = lfin_length l H2.
+  Proof. unfold lfin_length; f_equal; apply llist_list_eq. Qed.
   
   Fact lfin_length_fix_0 H : lfin_length lnil H = 0.
   Proof. unfold lfin_length; rewrite llist_list_fix_0; auto. Qed.

--- a/llist.v
+++ b/llist.v
@@ -1,0 +1,182 @@
+(**************************************************************)
+(*   Copyright Dominique Larchey-Wendling [*]                 *)
+(*             Ralph Matthes [+]                              *)
+(*                                                            *)
+(*                             [*] Affiliation LORIA -- CNRS  *)
+(*                             [*] Affiliation IRIT -- CNRS   *)
+(**************************************************************)
+(*      This file is distributed under the terms of the       *)
+(*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
+(**************************************************************)
+
+Require Import List Arith Omega Wellfounded Extraction.
+
+Set Implicit Arguments.
+
+Section llist.
+
+  (* G54DTP Dependently Typed Programming.
+    Introduction to coinductive types.
+    Venanzio Capretta, March 2011.
+  *)
+
+  Variable X : Type.
+
+  CoInductive llist : Type :=
+    | lnil: llist
+    | lcons: X -> llist -> llist.
+
+  (* We must define an explicit unfold operation. *)
+
+  Definition lunfold (l : llist) : llist :=
+    match l with
+      | lnil => lnil
+      | lcons a l' => lcons a l'
+    end.
+ 
+  (* The next function unfolds a lazy list several times:
+     the natural number n says how many.
+  *)
+
+  Fixpoint lunfold_many (l:llist) n : llist :=
+    match n with
+      | O    => l
+      | S n => match l with
+          | lnil      => lnil
+          | lcons a l => lcons a (lunfold_many l n)
+          end
+    end.
+
+  (* We can prove that the unfolding is equal to the original list. *)
+
+  Lemma lunfold_many_eq: forall n (l:llist), l = lunfold_many l n.
+  Proof.
+    induction n as [ | n IHn ].
+    + trivial.
+    + intros [ | x l ].
+      * trivial.
+      * simpl; f_equal; auto.
+  Qed.
+
+  (* Every finite list can be transformed into a lazy list. *)
+
+  Fixpoint list_llist l : llist :=
+    match l with
+      | nil  => lnil
+      | a::l => lcons a (list_llist l)
+    end.
+    
+  Fact list_llist_inj l m : list_llist l = list_llist m -> l = m.
+  Proof.
+    revert m; induction l as [ | x l IHl ]; intros [ | y m ]; auto; try discriminate.
+    simpl; intros H; inversion H; f_equal; auto.
+  Qed.
+    
+  Inductive lfin : llist -> Prop :=
+    | lfin_lnil :  lfin lnil
+    | lfin_lcons : forall a l, lfin l -> lfin (lcons a l).
+    
+  Fact lfin_inv a l : lfin (lcons a l) -> lfin l.
+  Proof. inversion 1; assumption. Defined.
+
+  Section llist_list.
+
+    Let llist_list_rec : forall l, lfin l -> { m | l = list_llist m }.
+    Proof.
+      refine (fix loop l Hl { struct Hl } := 
+        match l as l' return lfin l' -> { m | l' = list_llist m } with
+          | lnil      => fun H => exist _ nil _
+          | lcons x l => fun H => let (r,Hr) := loop l _ in exist _ (x::r) _
+        end Hl); subst; trivial.
+      inversion H; trivial.
+    Qed.
+  
+    Definition llist_list l Hl := proj1_sig (@llist_list_rec l Hl).
+  
+    Fact llist_list_spec l Hl : l = list_llist (@llist_list l Hl).
+    Proof. apply (proj2_sig (@llist_list_rec l Hl)). Qed.
+
+  End llist_list.
+  
+  Arguments llist_list : clear implicits.
+  
+  Fact llist_list_fix_0 H : llist_list lnil H = nil.
+  Proof.
+    generalize (llist_list_spec H); simpl.
+    generalize (llist_list _ H).
+    intros [|]; try discriminate; auto.
+  Qed.
+  
+  Fact llist_list_fix_1 x l H : llist_list (lcons x l) H = x::llist_list l (lfin_inv H).
+  Proof.
+    generalize (llist_list_spec H); simpl.
+    generalize (llist_list _ H).
+    intros [|]; try discriminate.
+    simpl.
+    intros G; inversion G; f_equal; auto.
+    apply list_llist_inj; rewrite <- H2.
+    apply llist_list_spec.
+  Qed.
+
+  Definition lfin_length l Hl := length (llist_list l Hl).
+
+  Arguments lfin_length : clear implicits.
+  
+  Fact lfin_length_fix_0 H : lfin_length lnil H = 0.
+  Proof. unfold lfin_length; rewrite llist_list_fix_0; auto. Qed.
+  
+  Fact lfin_length_fix_1 x l H : lfin_length (lcons x l) H = S (lfin_length l (lfin_inv H)).
+  Proof. unfold lfin_length; rewrite llist_list_fix_1; auto. Qed.
+  
+End llist.
+
+Arguments lnil {X}.
+Arguments llist_list {X}.
+Arguments lfin_length {X}.
+
+Section Rotate.
+
+  (* Rotate with lazy lists (with a non-informative "finiteness" predicate 
+     It seems the algorithm manipulates f a as lazy lists and r as a list ... no sure
+     or three lazy lists ? *)
+
+  Variable (X : Type).
+  
+  Implicit Type (f r : llist X) (a : list X).
+  
+  Let prec  f Hf r Hr := lfin_length r Hr = 1 + lfin_length f Hf.
+  Let rspec f Hf r Hr a m := m = llist_list f Hf++rev (llist_list r Hr)++a.
+  
+  Fixpoint rotate f r a (Hf : lfin f) (Hr : lfin r) { struct Hf } : @prec f Hf r Hr -> sig (@rspec f Hf r Hr a). 
+  Proof.
+    revert Hr.
+    refine (match r as r' return forall (Hr : lfin r'), @prec f Hf _ Hr  -> sig (@rspec f Hf r' Hr a) with
+      | lnil       => _
+      | lcons y r' => _ 
+    end); intros Hr' H.
+    { exfalso.
+      red in H.
+      rewrite lfin_length_fix_0 in H; discriminate. }
+    revert Hf H.
+    refine (match f as f' return forall (Hf' : lfin f'), @prec f' Hf' _ Hr' -> sig (rspec Hf' Hr' a) with
+      | lnil       => _
+      | lcons x f' => _
+    end); intros Hf' H.
+    + exists (y::a).
+      red in H |- *; revert H.
+      rewrite llist_list_fix_0, llist_list_fix_1, lfin_length_fix_0, lfin_length_fix_1.
+      destruct r'.
+      * rewrite llist_list_fix_0; trivial.
+      * rewrite lfin_length_fix_1; discriminate.
+    + refine (let (ro,Hro) := rotate f' r' (y::a) (lfin_inv Hf') (lfin_inv Hr') _ in exist _ (x::ro) _).
+      * red in H |- *; revert H.
+        repeat rewrite lfin_length_fix_1; intros; omega.
+      * red in Hro |- *; revert Hro.
+        repeat rewrite llist_list_fix_1; intros; subst.
+        simpl; rewrite app_ass; auto.
+  Defined.
+
+End Rotate.
+
+Recursive Extraction llist_list list_llist rotate.
+

--- a/queues.v
+++ b/queues.v
@@ -1,5 +1,15 @@
-Require Import List Arith Omega Wellfounded.
-Require Extraction.
+(**************************************************************)
+(*   Copyright Dominique Larchey-Wendling [*]                 *)
+(*             Ralph Matthes [+]                              *)
+(*                                                            *)
+(*                             [*] Affiliation LORIA -- CNRS  *)
+(*                             [*] Affiliation IRIT -- CNRS   *)
+(**************************************************************)
+(*      This file is distributed under the terms of the       *)
+(*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
+(**************************************************************)
+
+Require Import List Arith Omega Wellfounded Extraction.
 
 Set Implicit Arguments.
 
@@ -10,11 +20,11 @@ Section llist.
     Venanzio Capretta, March 2011.
   *)
 
-  Variable A : Type.
+  Variable X : Type.
 
   CoInductive llist : Type :=
     | lnil: llist
-    | lcons: A -> llist -> llist.
+    | lcons: X -> llist -> llist.
 
   (* We must define an explicit unfold operation. *)
 
@@ -28,18 +38,18 @@ Section llist.
      the natural number n says how many.
   *)
 
-  Fixpoint lunf (l:llist) n : llist :=
+  Fixpoint lunfold_many (l:llist) n : llist :=
     match n with
       | O    => l
       | S n => match l with
           | lnil      => lnil
-          | lcons a l => lcons a (lunf l n)
+          | lcons a l => lcons a (lunfold_many l n)
           end
     end.
 
   (* We can prove that the unfolding is equal to the original list. *)
 
-  Lemma lunf_eq: forall n (l:llist), l = lunf l n.
+  Lemma lunfold_many_eq: forall n (l:llist), l = lunfold_many l n.
   Proof.
     induction n as [ | n IHn ].
     + trivial.
@@ -50,13 +60,13 @@ Section llist.
 
   (* Every finite list can be transformed into a lazy list. *)
 
-  Fixpoint list_lazy (l:list A) : llist :=
+  Fixpoint list_llist l : llist :=
     match l with
       | nil  => lnil
-      | a::l => lcons a (list_lazy l)
+      | a::l => lcons a (list_llist l)
     end.
     
-  Fact list_lazy_inj l m : list_lazy l = list_lazy m -> l = m.
+  Fact list_llist_inj l m : list_llist l = list_llist m -> l = m.
   Proof.
     revert m; induction l as [ | x l IHl ]; intros [ | y m ]; auto; try discriminate.
     simpl; intros H; inversion H; f_equal; auto.
@@ -67,64 +77,64 @@ Section llist.
     | lfin_lcons : forall a l, lfin l -> lfin (lcons a l).
     
   Fact lfin_inv a l : lfin (lcons a l) -> lfin l.
-  Proof. inversion 1; assumption. Defined. 
+  Proof. inversion 1; assumption. Defined.
 
-  Let lazy_list_rec : forall l, lfin l -> { m | l = list_lazy m }.
+  Section llist_list.
+
+    Let llist_list_rec : forall l, lfin l -> { m | l = list_llist m }.
+    Proof.
+      refine (fix loop l Hl { struct Hl } := 
+        match l as l' return lfin l' -> { m | l' = list_llist m } with
+          | lnil      => fun H => exist _ nil _
+          | lcons x l => fun H => let (r,Hr) := loop l _ in exist _ (x::r) _
+        end Hl); subst; trivial.
+      inversion H; trivial.
+    Qed.
+  
+    Definition llist_list l Hl := proj1_sig (@llist_list_rec l Hl).
+  
+    Fact llist_list_spec l Hl : l = list_llist (@llist_list l Hl).
+    Proof. apply (proj2_sig (@llist_list_rec l Hl)). Qed.
+
+  End llist_list.
+  
+  Arguments llist_list : clear implicits.
+  
+  Fact llist_list_fix_0 H : llist_list lnil H = nil.
   Proof.
-    refine (fix loop l Hl { struct Hl } := _).
-    destruct l as [ | x l ].
-    + exists nil; trivial.
-    + refine (let (r,Hr) := loop l _
-              in  exist _ (x::r) _). 
-      * revert Hl; apply lfin_inv.
-      * simpl in Hr; subst; trivial.
-  Qed.
-  
-  Definition lazy_list l Hl := proj1_sig (@lazy_list_rec l Hl).
-  
-  Fact lazy_list_spec l Hl : l = list_lazy (@lazy_list l Hl).
-  Proof. apply (proj2_sig (@lazy_list_rec l Hl)). Qed.
-  
-  Arguments lazy_list : clear implicits.
-  
-  Fact lazy_list_fix_0 H : lazy_list lnil H = nil.
-  Proof.
-    generalize (lazy_list_spec H); simpl.
-    generalize (lazy_list _ H).
+    generalize (llist_list_spec H); simpl.
+    generalize (llist_list _ H).
     intros [|]; try discriminate; auto.
   Qed.
   
-  Fact lazy_list_fix_1 x l H : lazy_list (lcons x l) H = x::lazy_list l (lfin_inv H).
+  Fact llist_list_fix_1 x l H : llist_list (lcons x l) H = x::llist_list l (lfin_inv H).
   Proof.
-    generalize (lazy_list_spec H); simpl.
-    generalize (lazy_list _ H).
+    generalize (llist_list_spec H); simpl.
+    generalize (llist_list _ H).
     intros [|]; try discriminate.
     simpl.
     intros G; inversion G; f_equal; auto.
-    apply list_lazy_inj; rewrite <- H2.
-    apply lazy_list_spec.
+    apply list_llist_inj; rewrite <- H2.
+    apply llist_list_spec.
   Qed.
 
-  Definition lfin_length l Hl := length (@lazy_list l Hl).
+  Definition lfin_length l Hl := length (llist_list l Hl).
+
+  Arguments lfin_length : clear implicits.
   
-  Fact lfin_length_fix_0 H : @lfin_length lnil H = 0.
-  Proof.
-    unfold lfin_length.
-    rewrite lazy_list_fix_0; auto.
-  Qed.
+  Fact lfin_length_fix_0 H : lfin_length lnil H = 0.
+  Proof. unfold lfin_length; rewrite llist_list_fix_0; auto. Qed.
   
-  Fact lfin_length_fix_1 x l H : @lfin_length (lcons x l) H = S (lfin_length (lfin_inv H)).
-  Proof.
-    unfold lfin_length; rewrite lazy_list_fix_1; auto.
-  Qed.
+  Fact lfin_length_fix_1 x l H : lfin_length (lcons x l) H = S (lfin_length l (lfin_inv H)).
+  Proof. unfold lfin_length; rewrite llist_list_fix_1; auto. Qed.
   
 End llist.
 
-Arguments lnil {A}.
-Arguments lazy_list {A}.
-Arguments lfin_length {A}.
+Arguments lnil {X}.
+Arguments llist_list {X}.
+Arguments lfin_length {X}.
 
-Recursive Extraction lazy_list list_lazy.
+Recursive Extraction llist_list list_llist.
 
 Section Rotate.
 
@@ -137,7 +147,7 @@ Section Rotate.
   Implicit Type (f r : llist X) (a : list X).
   
   Let prec  f Hf r Hr := lfin_length r Hr = 1 + lfin_length f Hf.
-  Let rspec f Hf r Hr a m := m = lazy_list f Hf++rev (lazy_list r Hr)++a.
+  Let rspec f Hf r Hr a m := m = llist_list f Hf++rev (llist_list r Hr)++a.
   
   Fixpoint rotate f r a (Hf : lfin f) (Hr : lfin r) { struct Hf } : @prec f Hf r Hr -> sig (@rspec f Hf r Hr a). 
   Proof.
@@ -156,21 +166,21 @@ Section Rotate.
     end); intros Hf' H.
     + exists (y::a).
       red in H |- *; revert H.
-      rewrite lazy_list_fix_0, lazy_list_fix_1, lfin_length_fix_0, lfin_length_fix_1.
+      rewrite llist_list_fix_0, llist_list_fix_1, lfin_length_fix_0, lfin_length_fix_1.
       destruct r'.
-      * rewrite lazy_list_fix_0; trivial.
+      * rewrite llist_list_fix_0; trivial.
       * rewrite lfin_length_fix_1; discriminate.
     + refine (let (ro,Hro) := rotate f' r' (y::a) (lfin_inv Hf') (lfin_inv Hr') _ in exist _ (x::ro) _).
       * red in H |- *; revert H.
         repeat rewrite lfin_length_fix_1; intros; omega.
       * red in Hro |- *; revert Hro.
-        repeat rewrite lazy_list_fix_1; intros; subst.
+        repeat rewrite llist_list_fix_1; intros; subst.
         simpl; rewrite app_ass; auto.
   Defined.
 
 End Rotate.
 
-Extraction rotate.
+Recursive Extraction rotate.
 
 Record queue (X : Type) : Type := 
   { Q : Type;

--- a/wf_utils.v
+++ b/wf_utils.v
@@ -97,13 +97,13 @@ Tactic Notation "induction" "on" hyp(x) "as" ident(IH) "with" "measure" uconstr(
      define mes of x as (f : nat);
      set (rel x y := mes x < mes y);
      pattern x; match goal with
-       |- ?T _ => refine ((fix loop u (Hu : Acc rel u) { struct Hu } : T u := _) x _)
-     end;
-     [ pattern u;
-       match goal with |- ?t _ => assert (forall v, rel v u -> t v) as IH end;
-       [ intros v Hv; apply (loop v), (Acc_inv Hu), Hv 
-       | unfold rel, mes in *; clear mes rel Hu loop x; rename u into x ]
-     | unfold rel; apply wf_inverse_image, lt_wf ].
+       |- ?T _ => 
+       refine ((fix loop u (Hu : Acc rel u) { struct Hu } : T u := _) x _);
+       [ assert (forall v, rel v u -> T v) as IH;
+         [ intros v Hv; apply (loop v), (Acc_inv Hu), Hv 
+         | unfold rel, mes in *; clear mes rel Hu loop x; rename u into x ]
+       | unfold rel; apply wf_inverse_image, lt_wf ]
+     end.
 
 Tactic Notation "induction" "on" hyp(x) hyp(y) "as" ident(IH) "with" "measure" uconstr(f) :=
   generalize I; intro IH;

--- a/wf_utils.v
+++ b/wf_utils.v
@@ -82,10 +82,10 @@ Extraction Inline measure_rect measure_double_rect.
     by using measure_rect ...
 *)
 
-Local Tactic Notation "define" ident(f) "of" hyp(n) "as" uconstr(t)  :=
+Tactic Notation "define" ident(f) "of" hyp(n) "as" uconstr(t)  :=
   match type of n with ?N => pose (f (n : N) := t) end.
 
-Local Tactic Notation "define" ident(f) "of" hyp(n) hyp(m) "as" uconstr(t)  :=
+Tactic Notation "define" ident(f) "of" hyp(n) hyp(m) "as" uconstr(t)  :=
   match type of n with ?N =>  
     match type of m with ?M  => pose (f (n:N) (m:M) := t) end end.
 
@@ -96,7 +96,9 @@ Tactic Notation "induction" "on" hyp(x) "as" ident(IH) "with" "measure" uconstr(
   in clear IH;
      define mes of x as (f : nat);
      set (rel x y := mes x < mes y);
-     refine ((fix loop u (Hu : Acc rel u) { struct Hu } := _) x _);
+     pattern x; match goal with
+       |- ?T _ => refine ((fix loop u (Hu : Acc rel u) { struct Hu } : T u := _) x _)
+     end;
      [ pattern u;
        match goal with |- ?t _ => assert (forall v, rel v u -> t v) as IH end;
        [ intros v Hv; apply (loop v), (Acc_inv Hu), Hv 
@@ -111,7 +113,9 @@ Tactic Notation "induction" "on" hyp(x) hyp(y) "as" ident(IH) "with" "measure" u
   in clear IH; 
      define mes of x y as (f : nat);
      set (rel u v := mes (fst u) (snd u) < mes (fst v) (snd v)); unfold fst, snd in rel;
-     refine ((fix loop u v (Hu : Acc rel (u,v)) { struct Hu } := _) x y _);
+     pattern x, y; match goal with
+       |- ?T _ _ => refine ((fix loop u v (Hu : Acc rel (u,v)) { struct Hu } : T u v := _) x y _)
+     end;
      [ pattern u, v;
        match goal with |- ?t _ _ => assert (forall u' v', rel (u',v') (u,v) -> t u' v') as IH end;
        [ intros u' v' Hv; apply (loop u' v'), (Acc_inv Hu), Hv 


### PR DESCRIPTION
The generic BFN ([bfn_fifo_gen.v](bfn_fifo_gen.v)) is based on _axiomatized fifos_. These axioms are instantiated with fifos as pairs of lists or pairs of lazy lists following Okasaki's JFP95 paper on _"Simple and efficient purely functional queues and deques."_

Comparing with direct use of fifo_2q_* ([fifo.v](fifo.v) & [bfn_fifo_2l.v](bfn_fifo_2l.v)), the generic BFN of [bfn_fifo_gen.v](bfn_fifo_gen.v) does not have a so nice extraction.